### PR TITLE
Don't fail if coverage is less than 100%

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,5 +14,5 @@ commands = coverage run \
 changedir = .tox
 deps = coverage
 commands = coverage combine --rcfile={toxinidir}/.tox-coveragerc
-           coverage report --fail-under=100 -m
+           coverage report
            python -c 'import sys; open("{toxinidir}/.coverage", "w").write(open(".coverage").read())'


### PR DESCRIPTION
This prevents independent tox runs from reporting to codecov